### PR TITLE
FEDX-717: Update license to refer to `npx` license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,13 +1,17 @@
 Copyright 2024 Workiva Inc.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of the
+License at http://www.apache.org/licenses/LICENSE-2.0
 
-    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+This dpx software is based on the following software with separate copyright
+notice and license terms:
+
+npx: https://github.com/npm/npx
+Copyright npm, Inc.
+Licensed under the ISC license: https://github.com/npm/npx/blob/latest/LICENSE.md


### PR DESCRIPTION
Last change before open sourcing, need to update the license.