### PR TITLE
FEDX-951: Generate SBOM during CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,13 +10,29 @@ on:
       - '**'
 
 jobs:
-  dart:
+  build:
+    name: Dart build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+      - name: Install dependencies
+        run: dart pub get
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          path: ./
+          format: cyclonedx-json
+
+  checks:
     strategy:
       fail-fast: false
       matrix:
         os: [ ubuntu, windows ]
         sdk: [ 2.19.6, stable ]
-    name: Dart ${{ matrix.sdk }} on ${{ matrix.os }}
+    name: Dart checks - ${{ matrix.sdk }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}-latest
     steps:
       - uses: actions/checkout@v4
@@ -34,8 +50,3 @@ jobs:
         run: dart format --output=none --set-exit-if-changed .
       - name: Tests
         run: dart test
-      - name: Generate SBOM
-        uses: anchore/sbom-action@v0
-        with:
-          path: ./
-          format: cyclonedx-json


### PR DESCRIPTION
# [FEDX-951](https://jira.atl.workiva.net/browse/FEDX-951)
![Issue Status](https://h.plat-dev.workiva.org/s/wk-backend/jira/status/FEDX-951)

Last step before open sourcing this repo is to ensure that we generate a Software Bill of Materials (SBOM) on every build and release for dependency.