### PR TITLE
RM-265652 Release dpx 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
-## 0.1.0-wip
+## 0.1.0
 
 - Initial release.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dpx
-version: 0.1.0-wip
+version: 0.1.0
 description: Execute Dart package binaries
 repository: https://github.com/Workiva/dpx
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Initial implementation](https://github.com/Workiva/dpx/pull/1)
	* [Improve handling of exit codes](https://github.com/Workiva/dpx/pull/2)
	* [FEDX-657: Add OSS license and starting version](https://github.com/Workiva/dpx/pull/3)
	* [FEDX-717: Update license to refer to `npx` license](https://github.com/Workiva/dpx/pull/4)
	* [FEDX-727: Update NOTICE file with new license information](https://github.com/Workiva/dpx/pull/5)
	* [FEDX-812 Improve CLI ergonomics](https://github.com/Workiva/dpx/pull/6)
	* [FEDX-951: Generate SBOM during CI](https://github.com/Workiva/dpx/pull/7)
	* [FEDX-954: Add initial changelog and a `dart pub publish --dry-run` CI check](https://github.com/Workiva/dpx/pull/8)


Requested by: @evanweible-wf

Diff Between Last Tag and Proposed Release: N/A
Diff Between Last Tag and New Tag: N/A

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5176949306163200/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/5176949306163200/?repo_name=Workiva%2Fdpx&pull_number=9)