### PR TITLE
FEDX-965: Readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ used.
 
 ## Package Sources
 
-The first arg to `dpx` or the value of the `--package` option is referred to as
-a `<package-spec>`, which supports several different formats to enable
-installing from different sources and targeting specific versions.
+The first arg to `dpx` is referred to as a `<package-spec>`, which supports
+several different formats to enable installing from different sources and
+targeting specific versions.
 
 ```bash
 # Install from pub with an optional version constraint.

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,24 @@
+Install `dpx`:
+```bash
+dart pub global activate dpx
+```
+
+Run the example:
+```bash
+> dart pub global run dpx github:Workiva/dpx#path=example/dpx_hello
+# Or if you have Dart global executables in your path:
+> dpx github:Workiva/dpx#path=example/dpx_hello
+Need to install the following packages:
+Git repository "https://github.com/Workiva/dpx.git" at path "example/dpx_hello"
+Ok to proceed? (y/n) y
+8 888888888o.      8 888888888o   `8.`8888.      ,8'
+8 8888    `^888.   8 8888    `88.  `8.`8888.    ,8'
+8 8888        `88. 8 8888     `88   `8.`8888.  ,8'
+8 8888         `88 8 8888     ,88    `8.`8888.,8'
+8 8888          88 8 8888.   ,88'     `8.`88888'
+8 8888          88 8 888888888P'      .88.`8888.
+8 8888         ,88 8 8888            .8'`8.`8888.
+8 8888        ,88' 8 8888           .8'  `8.`8888.
+8 8888    ,o88P'   8 8888          .8'    `8.`8888.
+8 888888888P'      8 8888         .8'      `8.`8888.
+```


### PR DESCRIPTION
- Remove a reference to an outdated CLI option
- Add a basic example readme for the `pub.dev` view