### PR TITLE
FEDX-967: Lengthen package description

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dpx
 version: 0.1.0
-description: Execute Dart package binaries
+description: Easily install and execute Dart package binaries with one command.
 repository: https://github.com/Workiva/dpx
 
 environment:


### PR DESCRIPTION

Pub package description needs to be a minimum of 60 chars to get full points on pub.dev.