### PR TITLE
FEDX-970: Disallow (ignore) trailing options, as it inhibits ability to pass args to subcommand

### DIFF
--- a/lib/src/args.dart
+++ b/lib/src/args.dart
@@ -5,7 +5,7 @@ import 'package:dpx/src/exit_exception.dart';
 import 'package:dpx/src/version.dart';
 import 'package:io/io.dart';
 
-final argParser = ArgParser()
+final argParser = ArgParser(allowTrailingOptions: false)
   ..addFlag('help', abbr: 'h', negatable: false)
   ..addFlag('interactive', abbr: 'i', negatable: false, hide: true)
   ..addFlag('verbose', abbr: 'v', negatable: false)


### PR DESCRIPTION
I removed the `allowTrailingOptions: false` in a recent PR, only to remember that it was supposed to be disabled. When trailing options are allowed, it becomes impossible to pass options/flags as args to the subcommand that `dpx` runs since the top-level `dpx` arg parser will try to parse them.

For example:

```bash
> dpx dependency_validator --help
```

This should run `dependency_validator --help` and display the help output for that executable, but it actually displays the help output for `dpx`. Similarly, if you tried to use a CLI flag or option of the subcommand, `dpx` would fail to parse args altogether.

While it's possible to workaround this by using an arg separator...

```bash
> dpx dependency_validator -- --help
```

... it's awkward and unintuitive. `dpx` is supposed to make it as easy to run other package executables, so we should aim to make the `dpx` CLI get out of the way whenever possible and favor the underlying package executable.

This PR makes that change by disallowing (ignoring) trailing options.

Note: the only real downside is that if you want to make `dpx` run in verbose mode, you have to add the `--verbose` flag first, like so:

```bash
> dpx --verbose dependency_validator
```

This is a minor inconvenience and an acceptable trade off. 