### PR TITLE
Release dpx 0.1.2

### DIFF
--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.0.0';
+const packageVersion = '0.1.2';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dpx
-version: 0.1.1
+version: 0.1.2
 description: Easily install and execute Dart package binaries with one command.
 repository: https://github.com/Workiva/dpx
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [FEDX-1093: Use full Apache 2.0 license text](https://github.com/Workiva/dpx/pull/23)


Requested by: @evanweible-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dpx/compare/0.1.1...Workiva:release_dpx_0.1.2
Diff Between Last Tag and New Tag: https://github.com/Workiva/dpx/compare/0.1.1...0.1.2

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5176949306163200/logs/)