### PR TITLE
RM-269303 Release dpx 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.1
+
+- #30 Default `-y` when ran from a non-interactive terminal
+
 ## 0.2.0
 
 - #18 Disallow trailing options so that it's easier to pass args to the

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.2.0';
+const packageVersion = '0.2.1';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dpx
-version: 0.2.0
+version: 0.2.1
 description: Easily install and execute Dart package binaries with one command.
 repository: https://github.com/Workiva/dpx
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [FEDX-2413: Default `-y` when ran from a non-interactive termainal](https://github.com/Workiva/dpx/pull/30)


Requested by: @matthewnitschke-wk

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dpx/compare/0.2.0...Workiva:release_dpx_0.2.1
Diff Between Last Tag and New Tag: https://github.com/Workiva/dpx/compare/0.2.0...0.2.1

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5176949306163200/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/5176949306163200/?repo_name=Workiva%2Fdpx&pull_number=32)